### PR TITLE
Add support for ESP32 boards. Only UART version works for now.

### DIFF
--- a/energyic_SPI.h
+++ b/energyic_SPI.h
@@ -14,6 +14,8 @@
 #ifndef __ATM90E26_SPI_H__
 #define __ATM90E26_SPI_H__
 
+#include <Arduino.h>
+
 #define SoftReset 0x00 //Software Reset
 #define SysStatus 0x01 //System Status
 #define FuncEn 0x02 //Function Enable

--- a/energyic_UART.cpp
+++ b/energyic_UART.cpp
@@ -42,7 +42,11 @@ unsigned short ATM90E26_UART::CommEnergyIC(unsigned char RW,unsigned char addres
       ATM_UART->write(LSBWrite);
   }
   ATM_UART->write(host_chksum);
+  #if defined(ESP32)
+  delay(40); //Somehow, Arduino framework for ESP32 needs this delay
+  #else
   delay(10);
+  #endif
 
   //Read register only
   if(RW)

--- a/examples/ATM90E26_UART/ATM90E26_UART.ino
+++ b/examples/ATM90E26_UART/ATM90E26_UART.ino
@@ -1,5 +1,5 @@
 #include <energyic_UART.h>
-#if !defined(ARDUINO_ARCH_SAMD)
+#if !defined(ARDUINO_ARCH_SAMD) && !defined(ESP32)
 #include <SoftwareSerial.h>
 #else
 
@@ -29,17 +29,31 @@ SoftwareSerial ATMSerial(11, 13); //RX, TX
 Uart ATMSerial(&sercom1, PIN_SerialATM_RX, PIN_SerialATM_TX, PAD_SerialATM_RX, PAD_SerialATM_TX);
 #endif
 
+#if defined(ESP32)
+#define PIN_SerialATM_RX       19   //RX pin, CHANGE IT according to your board
+#define PIN_SerialATM_TX       23   //TX pin, CHANGE IT according to your board
+HardwareSerial ATMSerial(1);        //1 = just hardware serial number. ESP32 supports 3 hardware serials. UART 0 usually for flashing.
+#endif
+
 ATM90E26_UART eic(&ATMSerial);
 
 void setup() {
   Serial.begin(115200);
   Serial.println("\nATM90E26 UART Test Started");
+  
   #if defined(ARDUINO_ARCH_SAMD)
   pinPeripheral(PIN_SerialATM_RX, PIO_SERCOM);
   pinPeripheral(PIN_SerialATM_TX, PIO_SERCOM);
   #endif
+
+  #if defined(ESP32)
+  //Must begin ATMSerial before IC init supplying baud rate, serial config, and RX TX pins
+  ATMSerial.begin(9600, SERIAL_8N1, PIN_SerialATM_RX, PIN_SerialATM_TX);
+  #else
   //Must begin ATMSerial before IC init
   ATMSerial.begin(9600);
+  #endif
+  
   eic.InitEnergyIC();
   delay(1000);
 }
@@ -61,10 +75,20 @@ void loop() {
   Serial.println(eic.GetMeterStatus(),HEX);
   delay(10);
   Serial.print("Voltage:");
+  #if defined(ESP32)
+  //ESP32 or maybe another MCU support formatting float/double value
+  Serial.printf("%.4f V\n", eic.GetLineVoltage());
+  #else
   Serial.println(eic.GetLineVoltage());
+  #endif
   delay(10);
   Serial.print("Current:");
+  #if defined(ESP32)
+  //ESP32 or maybe another MCU support formatting float/double value
+  Serial.printf("%.4f A\n", eic.GetLineCurrent());
+  #else
   Serial.println(eic.GetLineCurrent());
+  #endif
   delay(10);
   Serial.print("Active power:");
   Serial.println(eic.GetActivePower());


### PR DESCRIPTION
Hi @whatnick 
This is Andri, the one who discuss with you on Tindie message. As you requested, I create PR, making this library works for ESP32 board. Only UART version works for now. I modified the UART example a bit.
Do let me know if you have concerns. Thanks.