### PR TITLE
Clear stale data in Serial buffer before txn

### DIFF
--- a/energyic_UART.cpp
+++ b/energyic_UART.cpp
@@ -39,6 +39,8 @@ unsigned short ATM90E26_UART::CommEnergyIC(unsigned char RW,
     host_chksum = chksum_short & 0xFF;
   }
 
+  // Clear out any data left in the buffer so it does not interfere later
+  ATM_UART->read();
   // begin UART command
   ATM_UART->write(0xFE);
   ATM_UART->write(address);


### PR DESCRIPTION
This change got it working for me on an ESP8266 (NodeMCU v1.0) running the latest 2.7.x libraries, not sure if it's necessary or functional on other hardware.