### PR TITLE
add GetChecksum function

### DIFF
--- a/energyic_UART.cpp
+++ b/energyic_UART.cpp
@@ -137,6 +137,25 @@ unsigned short ATM90E26_UART::GetSysStatus() {
   return CommEnergyIC(1, SysStatus, 0xFFFF);
 }
 
+uint16_t ATM90E26_UART::GetChecksum(const uint16_t *hex_values, int length)
+{
+    uint16_t value = 0x0000;
+    uint8_t lsb, msb;
+    int chk1 = 0, chk2 = 0;
+
+    for (int i = 0; i < length; i++)
+    {
+        msb = (hex_values[i] >> 8);
+        lsb = (hex_values[i] & 0x00FF);
+        chk1 += msb + lsb;
+        chk2 ^= msb ^ lsb;
+    }
+    value = chk1 % 0x100;
+    value += (chk2 << 8);  
+
+    return value;
+}
+
 /*
 Initialise Energy IC, assume UART has already began in the main code
 */

--- a/energyic_UART.h
+++ b/energyic_UART.h
@@ -48,6 +48,7 @@
 #define QNolTh 0x2A    // Reactive No-Load Power Threshold
 #define MMode 0x2B     // Metering Mode Configuration
 #define CSOne 0x2C     // Checksum 1
+#define CfgRegLen1 11   // Length of register for Checksum 1
 #define AdjStart 0x30  // Measurement Calibration Start Command
 #define Ugain 0x31     // Voltage rms Gain
 #define IgainL 0x32    // L Line Current rms Gain
@@ -60,6 +61,7 @@
 #define PoffsetN 0x39  // N Line Active Power Offset
 #define QoffsetN 0x3A  // N Line Reactive Power Offset
 #define CSTwo 0x3B     // Checksum 2
+#define CfgRegLen2 10  // Length of register for Checksum 2
 #define APenergy 0x40  // Forward Active Energy
 #define ANenergy 0x41  // Reverse Active Energy
 #define ATenergy 0x42  // Absolute Active Energy
@@ -95,6 +97,7 @@ public:
   void InitEnergyIC();
   unsigned short GetSysStatus();
   unsigned short GetMeterStatus();
+  unsigned short GetChecksum(unsigned short *hex_values, int length);
 
 private:
   unsigned short CommEnergyIC(unsigned char RW, unsigned char address,

--- a/energyic_UART.h
+++ b/energyic_UART.h
@@ -48,7 +48,7 @@
 #define QNolTh 0x2A    // Reactive No-Load Power Threshold
 #define MMode 0x2B     // Metering Mode Configuration
 #define CSOne 0x2C     // Checksum 1
-#define CfgRegLen1 11   // Length of register for Checksum 1
+#define CfgRegLen1 11  // Amount of register for Checksum 1
 #define AdjStart 0x30  // Measurement Calibration Start Command
 #define Ugain 0x31     // Voltage rms Gain
 #define IgainL 0x32    // L Line Current rms Gain
@@ -61,7 +61,7 @@
 #define PoffsetN 0x39  // N Line Active Power Offset
 #define QoffsetN 0x3A  // N Line Reactive Power Offset
 #define CSTwo 0x3B     // Checksum 2
-#define CfgRegLen2 10  // Length of register for Checksum 2
+#define CfgRegLen2 10  // Amount of register for Checksum 2
 #define APenergy 0x40  // Forward Active Energy
 #define ANenergy 0x41  // Reverse Active Energy
 #define ATenergy 0x42  // Absolute Active Energy


### PR DESCRIPTION
So a friend of mine had a hard time fighting with the checksum. It would be nice to have a function that calculates that for you. In the master branch i added this function as **GetChecksum**. It receives an array containing the information of registers and the length of the array (amount of registers to write into). Then it returns the checksum:
```C++
unsigned short ATM90E26_UART::GetChecksum(unsigned short *hex_values, int length) {
    unsigned short value = 0x0000;
    unsigned char lsb, msb;
    int chk1 = 0, chk2 = 0;

    for (int i = 0; i < length; i++) {
        msb = (hex_values[i] >> 8);
        lsb = (hex_values[i] & 0x00FF);
        chk1 += msb + lsb;
        chk2 ^= msb ^ lsb;
    }
    value = chk1 % 0x100;
    value += (chk2 << 8);  

    return value;
}
```

This function gets the defined checksum from datasheet. For testing you can do literally `gcc main.c` copying the following code:

```C++
#include <stdio.h>

#define CfgRegLen1 11  // Amount of register for Checksum 1
#define CfgRegLen2 10  // Amount of register for Checksum 2
#define PLconstH 0x21  // High Word of PL_Constant
#define PLconstL 0x22  // Low Word of PL_Constant
#define Lgain 0x23     // L Line Calibration Gain
#define Lphi 0x24      // L Line Calibration Angle
#define Ngain 0x25     // N Line Calibration Gain
#define Nphi 0x26      // N Line Calibration Angle
#define PStartTh 0x27  // Active Startup Power Threshold
#define PNolTh 0x28    // Active No-Load Power Threshold
#define QStartTh 0x29  // Reactive Startup Power Threshold
#define QNolTh 0x2A    // Reactive No-Load Power Threshold
#define MMode 0x2B     // Metering Mode Configuration
#define Ugain 0x31     // Voltage rms Gain
#define IgainL 0x32    // L Line Current rms Gain
#define IgainN 0x33    // N Line Current rms Gain
#define Uoffset 0x34   // Voltage Offset
#define IoffsetL 0x35  // L Line Current Offset
#define IoffsetN 0x36  // N Line Current Offse
#define PoffsetL 0x37  // L Line Active Power Offset
#define QoffsetL 0x38  // L Line Reactive Power Offset
#define PoffsetN 0x39  // N Line Active Power Offset
#define QoffsetN 0x3A  // N Line Reactive Power Offset

unsigned short GetChecksum(unsigned short *hex_values, unsigned short length) {
    unsigned short value = 0x0000;
    unsigned char lsb, msb;
    int chk1 = 0, chk2 = 0;

    for (int i = 0; i < length; i++) {
        msb = (hex_values[i] >> 8);
        lsb = (hex_values[i] & 0x00FF);
        chk1 += msb + lsb;
        chk2 ^= msb ^ lsb;
    }
    value = chk1 % 0x100;
    value += (chk2 << 8);  

    return value;
}

int main()
{
    unsigned char reg_adr1[CfgRegLen1] = {PLconstH,PLconstL,Lgain,Lphi,Ngain,Nphi,PStartTh,PNolTh,QStartTh,QNolTh,MMode};
    unsigned short reg_values1[CfgRegLen1] = {0x00B9,0xC1F3,0x1D39,0x0000,0x0000,0x0000,0x08BD,0x0000,0x0AEC,0x0000,0x9422};

    unsigned char reg_adr2[CfgRegLen2] = {Ugain,IgainL,IgainN,Uoffset,IoffsetL,IoffsetN,PoffsetL,QoffsetL,PoffsetN,QoffsetN};
    unsigned short reg_values2[CfgRegLen2] = {0xD464,0x6E49,0x7530,0x0000,0x0000,0x0000,0x0000,0x0000,0x0000,0x0000};

    printf("Checksum1: %04X\n", GetChecksum(reg_values1, CfgRegLen1));
    printf("Checksum2: %04X\n", GetChecksum(reg_values2, CfgRegLen2));

    return 0;
}
```
Maybe more assist is needed so `InitEnergyIC()` function can receive properly a _init_config_t_ struct with initial configuration...

Regards!